### PR TITLE
Fix the following deprecation from urfave/cli

### DIFF
--- a/cmd/ytdl/main.go
+++ b/cmd/ytdl/main.go
@@ -90,7 +90,7 @@ func main() {
 		},
 	}
 
-	app.Action = func(c *cli.Context) {
+	app.Action = func(c *cli.Context) error {
 		identifier := c.Args().First()
 		if identifier == "" || c.Bool("help") {
 			cli.ShowAppHelp(c)
@@ -118,6 +118,7 @@ func main() {
 			}
 			handler(identifier, options)
 		}
+		return nil
 	}
 	app.Run(os.Args)
 }

--- a/video_info_test.go
+++ b/video_info_test.go
@@ -10,7 +10,7 @@ func TestVideoInfo(t *testing.T) {
 	testCases := map[string]bool{
 		"https://www.youtube.com/watch?v=YQHsXMglC9A":            true,
 		"https://www.youtube.com/watch?v=H-30B0cqh88":            true,
-		"https://www.youtube.com/watch?v=qD8hOJoOGtk":            true,
+		"https://www.youtube.com/watch?v=dQw4w9WgXcQ":            true,
 		"https://www.youtube.com/":                               false,
 		"https://www.youtube.com/watch?v=qHGTs1NSB1s":            true,
 		"https://www.facebook.com/video.php?v=10153820411888896": false,


### PR DESCRIPTION
Specifying an Action with the legacy return signature of func(*cli.Context) will produce a deprecation message to stderr.